### PR TITLE
added o2c/c2o convenience methods, semi-automated directory search

### DIFF
--- a/HOA/HelpSource/Classes/HOA.schelp
+++ b/HOA/HelpSource/Classes/HOA.schelp
@@ -11,15 +11,15 @@ It is modeled after the Atk class.
 CLASSMETHODS::
 
 METHOD:: userSupportDir
-set the user support dir where HOA resources are located
-
-argument:: userSupportDirIn
-the path to the HOA folder containing your HOA support files
-
-METHOD:: userSupportDir
 
 returns::the path to the HOA support dir. Defaults to:
 code::Platform.userAppSupportDir.dirname ++ "/HOA";::
+
+METHOD:: systemSupportDir
+
+returns::the path to the HOA support dir. Defaults to:
+code::Platform.systemAppSupportDir.dirname ++ "/HOA";::
+
 
 METHOD:: userSoundsDir
 
@@ -29,24 +29,58 @@ METHOD:: userKernelDir
 
 returns:: a path to the 'kernel' dir inside the ATK support dir
 
-METHOD:: systemSupportDir
-
-returns::the path to the HOA support dir. Defaults to:
-code::Platform.systemAppSupportDir.dirname ++ "/HOA";::
 
 METHOD:: systemSoundsDir
 
-returns:: a path to the 'sounds' dir inside the HOA system support dir
+returns:: a path to the sounds dir inside the HOA system support dir
 
 METHOD:: systemKernelDir
 
-returns:: a path to the 'kernel' dir inside the HOA system support dir
+returns:: a path to the kernel dir inside the HOA system support dir
+
+METHOD:: kernelSubdir
+name of subdirectory for kernels within code::userSupportDir:: and code::systemSupportDir::
+
+METHOD:: soundsSubdir
+name of subdirectory for sounds within code::userSupportDir:: and code::systemSupportDir::
+
 
 METHOD:: openUserSupportDir
 runs a unixCmd to open the userAppSupport dir. Uses 'open' (OS X only)
 
-METHOD:: createUserSupportDir
-runs a unix cmd to create the user support dir for HOA
-
 METHOD:: openSystemSupportDir
 runs a unixCmd to open the systemAppSupport dir. Uses 'open' (OS X only)
+
+
+METHOD:: kernelDirsFor
+argument:: keyword
+string, possibly with wildcards, identifying the kernel subdirectory
+argument:: subPaths
+string woth subpahts leading to keyword
+
+code::
+// return all directories in <kernels>/FIR/hrir containing the string "lebedev"
+HOA.kernelDirsFor("*lebedev*", "FIR/hrir").first
+::
+
+returns:: array of paths matching the given parameters
+
+
+METHOD:: soundsDirsFor
+argument:: keyword
+string, possibly with wildcards, identifying the sounds subdirectory
+argument:: subPaths
+string woth subpahts leading to keyword
+
+returns:: array of paths matching the given parameters
+
+
+METHOD:: o2c
+argument:: n
+order
+returns:: channel count for given order
+
+METHOD:: c2o
+argument:: n
+channel count
+returns:: order for given channel count

--- a/HOA/HelpSource/Tutorials/Exercise_04_HOA_plane_versus_spherical_waves.schelp
+++ b/HOA/HelpSource/Tutorials/Exercise_04_HOA_plane_versus_spherical_waves.schelp
@@ -12,7 +12,7 @@ link::Tutorials/Exercise_05_HOA_b_format_file_playback::
 
 
 The examples below demonstarte the difference between plane and spherical waves.
-Sperical waves apply nearfield filters to account not only for directions but also for the distance of sound sources.
+Spherical waves apply nearfield filters to account not only for directions but also for the distance of sound sources.
 For the correct use of the distance filters, which are unstable by nature, take care about the distance parameters in the encoding and decoding step.
 
 In case you have not done so yet: let's start the sound server, which we configure first to get more audio buses and to have 36 output channels.

--- a/HOA/classes/HOA.sc
+++ b/HOA/classes/HOA.sc
@@ -1,49 +1,91 @@
 /*
-This class is based on the ATK class, in fact it only changes the name to HOA ;-) Thank you ATK!
+This class is based on the ATK class
+Thank you ATK!
+
+additions and alterations by Till Bovermann ( http://tai-studio.org )
 */
 
 
 HOA {
-	classvar <userSupportDir, <userSoundsDir, <userKernelDir;
-	classvar <systemSupportDir, <systemSoundsDir, <systemKernelDir;
+	classvar   <>userSupportDir; //,   <userSoundsDir,   <userKernelDir;
+	classvar <>systemSupportDir; //, <systemSoundsDir, <systemKernelDir;
+	classvar <>soundsSubdir, <>kernelSubdir;
 
 	*initClass {
-		userSupportDir = Platform.userAppSupportDir.dirname ++ "/HOA";		userSoundsDir = userSupportDir ++ "/sounds";
-		userKernelDir = userSupportDir ++ "/kernels";
-		systemSupportDir = Platform.systemAppSupportDir.dirname ++ "/HOA";		systemSoundsDir = systemSupportDir ++ "/sounds";
-		systemKernelDir = systemSupportDir ++ "/kernels";
+		systemSupportDir = Platform.systemAppSupportDir.dirname ++ "/HOA";
+		userSupportDir   = Platform.userAppSupportDir  .dirname ++ "/HOA";
+
+		soundsSubdir     = "sounds";
+		kernelSubdir     = "kernels";
+
 	}
 
-	*userSupportDir_ {arg userSupportDirIn;
-		userSupportDir = userSupportDirIn;
-		userSoundsDir = userSupportDir ++ "/sounds";
-		userKernelDir = userSupportDir ++ "/kernels";
+
+	*userSoundsDir {
+		systemSupportDir +/+ soundsSubdir;
+	}
+	*systemSoundsDir {
+		systemSupportDir +/+ soundsSubdir;
 	}
 
-	*systemSupportDir_ {arg systemSupportDurIn;
-		systemSupportDir = systemSupportDurIn;
-		systemSoundsDir = systemSupportDir ++ "/sounds";
-		systemKernelDir = systemSupportDir ++ "/kernels";
+	*userKernelDir {
+		systemSupportDir +/+ kernelSubdir;
+	}
+	*systemKernelDir {
+		systemSupportDir +/+ kernelSubdir;
 	}
 
 	*openUserSupportDir {
-		File.exists(Atk.userSupportDir).if({
+		if (File.exists(Atk.userSupportDir).not, {
 			HOA.userSupportDir.openOS;
 		}, {
-			"User Support Dir may not exist. Run \n\tHOA.createUserSupportDir\nto create it".warn
+			"\n%: User Support directory does not exist. Run\n"
+			"\tthis.createUserSupportDir\nto create it".format(this, this).warn;
+			^this;
 		})
 	}
 
-	*createUserSupportDir {
-		File.mkdir(HOA.userSupportDir);
-//		("mkdir \"" ++ HOA.userSupportDir ++ "\"").unixCmd;
-	}
+	// not really a good idea, we cannot populate it from within SC anyhow...
+	// *createUserSupportDir {
+	// 	"%: creating directory at %"
+	// 	.format(this, userSupportDir).inform
+	// 	File.mkdir(userSupportDir);
+	// 	//		("mkdir \"" ++ HOA.userSupportDir ++ "\"").unixCmd;
+	// }
 
 	*openSystemSupportDir {
-		File.exists(HOA.systemSupportDir).if({
-			HOA.systemSupportDir.openOS;
-		}, {
-			"System Support Dir may not exist.".warn
-		})
+		if (File.exists(systemSupportDir).not, {
+			"%: HOA System Support directory does not exist.".format(this).warn;
+			^this;
+		});
+
+		systemSupportDir.openOS;
 	}
+
+	*pr_dirsFor {|keyword, subdir, subPaths|
+		var paths;
+		// user directory takes precedence
+		paths = [userSupportDir, systemSupportDir].collect{|dir|
+			(dir +/+ subdir +/+ subPaths +/+ keyword).pathMatch;
+		}.flatten;
+
+		^paths;
+
+	}
+
+	*kernelDirsFor {|keyword, subPaths|
+		^this.pr_dirsFor(keyword, kernelSubdir, subPaths);
+	}
+	*soundsDirsFor {|keyword, subPaths|
+		^this.pr_dirsFor(keyword, soundsSubdir, subPaths);
+	}
+
+	*o2c {|n|
+		^((n+1).squared)
+	}
+
+	*c2o {|n|
+		^(n.sqrt - 1)
+	}
+
 }

--- a/HOA/classes/HOADecLebedev.sc
+++ b/HOA/classes/HOADecLebedev.sc
@@ -1,3 +1,8 @@
+/*
+2016/2017 Florian Grond
+additions by Till Bovermann ( http://tai-studio.org )
+*/
+
 HOADecLebedev06 : HOADecLebedev {
 	classvar <>hrirFilters;
 	classvar <numChannels;
@@ -27,7 +32,17 @@ HOADecLebedev26 : HOADecLebedev {
 HOADecLebedev {
 	*loadHrirFilters {|server, path|
 
-		path = path ?? {HOA.userKernelDir++"/FIR/hrir/hrir_lebedev50/"};
+		// make path contain something usable
+		path = if (path.isNil, {
+			HOA.kernelDirsFor("*lebedev50", "FIR/hrir")
+		}, {
+			path.pathMatch;
+		}).first;
+
+		if (path.isNil, {
+			"%: specified path is nil".format(this).error;
+			^this;
+		});
 
 		this.hrirFilters = this.numChannels.collect({|i|	[
 			Buffer.read(server, path ++"/hrir_"++(i+1)++"_L.wav"),


### PR DESCRIPTION
this removes the necessity to provide a path to `HOADecLebedev06.loadHrirFilters`, making it easier to follow the tutorials.

This explains it quite well:
```
// set userSupportDir and kernelSubdir once
HOA.userSupportDir = "/localvol/sound/src/ambitools/";
HOA.kernelSubdir = "";

// use HOADecLebedev26 without specifying a path
HOADecLebedev26.loadHrirFilters(s);
```

also, I added two convenience methods calculating

+ the number of channels from a given order (`HOA.o2c`)
+ the order from a given number of channels (`HOA.c2o`)
