### PR TITLE
Quarcks revision to work with sc3-pluginsHOA branch

### DIFF
--- a/classes/HOABeamDirac2Hoa.sc
+++ b/classes/HOABeamDirac2Hoa.sc
@@ -7,7 +7,7 @@ HOABeamDirac2Hoa{
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^FaustHOABeamDirac2HOA1.ar(in1, // return the Ugen with the b-format channels
+			              ^HOABeamDirac2HOA1.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            azimuth: az, elevation: ele, gain:level, on: on, crossfade:crossfade)} // and with the args from the *ar method
 		       {order == 2}
@@ -17,7 +17,7 @@ HOABeamDirac2Hoa{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^FaustHOABeamDirac2HOA2.ar(in1, // return the Ugen with the b-format channels
+			              ^HOABeamDirac2HOA2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
 				                                            azimuth: az, elevation: ele, gain:level, on: on, crossfade:crossfade)} // and with the args from the *ar method
@@ -30,7 +30,7 @@ HOABeamDirac2Hoa{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^FaustHOABeamDirac2HOA3.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOABeamDirac2HOA3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -46,7 +46,7 @@ HOABeamDirac2Hoa{
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25 = in;
-			             ^FaustHOABeamDirac2HOA4.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOABeamDirac2HOA4.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -65,7 +65,7 @@ HOABeamDirac2Hoa{
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25,
 			                    in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 = in;
-			             ^FaustHOABeamDirac2HOA5.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOABeamDirac2HOA5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,

--- a/classes/HOABeamHCard2Hoa.sc
+++ b/classes/HOABeamHCard2Hoa.sc
@@ -7,7 +7,7 @@ HOABeamHCard2Hoa{
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^FaustHOABeamHCardio2HOA1.ar(in1, // return the Ugen with the b-format channels
+			              ^HOABeamHCardio2HOA1.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            azimuth: az, elevation: ele, order:cardOrder)} // and with the args from the *ar method
 		       {order == 2}
@@ -17,7 +17,7 @@ HOABeamHCard2Hoa{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^FaustHOABeamHCardio2HOA2.ar(in1, // return the Ugen with the b-format channels
+			              ^HOABeamHCardio2HOA2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
 				                                            azimuth: az, elevation: ele, order:cardOrder)}// and with the args from the *ar method
@@ -30,7 +30,7 @@ HOABeamHCard2Hoa{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^FaustHOABeamHCardio2HOA3.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOABeamHCardio2HOA3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -49,7 +49,7 @@ HOABeamHCard2Hoa{
 				"order 4 is not implemented for HOABeamHCardio2HOA. \n returning unaltered bformat.".postln;
 			^[ in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25 ]
 		/*
-			^FaustHOABeamHCardio2HOA4.ar(in1,  // return the Ugen with the b-format channels
+			^HOABeamHCardio2HOA4.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -74,7 +74,7 @@ HOABeamHCard2Hoa{
 			^[ in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36]
 
 			/*
-			^FaustHOABeamHCardio2HOA5.ar(in1,  // return the Ugen with the b-format channels
+			^HOABeamHCardio2HOA5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,

--- a/classes/HOABeamHCard2Mono.sc
+++ b/classes/HOABeamHCard2Mono.sc
@@ -6,7 +6,7 @@ HOABeamHCard2Mono{
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^FaustHOABeamHCardio2Mono1.ar(in1, // return the Ugen with the b-format channels
+			              ^HOABeamHCardio2Mono1.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            azimuth: az, elevation: ele, output_gain: gain)} // and with the args from the *ar method
 		       {order == 2}
@@ -16,7 +16,7 @@ HOABeamHCard2Mono{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^FaustHOABeamHCardio2Mono2.ar(in1, // return the Ugen with the b-format channels
+			              ^HOABeamHCardio2Mono2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
 				                                           azimuth: az, elevation: ele, output_gain: gain)} // and with the args from the *ar method
@@ -29,7 +29,7 @@ HOABeamHCard2Mono{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^FaustHOABeamHCardio2Mono3.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOABeamHCardio2Mono3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -48,7 +48,7 @@ HOABeamHCard2Mono{
 				"order 4 is not implemented for HOABeamHCardio2Mono. \n returning unaltered omni channel.".postln;
 			^[ in1]
 		/*
-			^FaustHOABeamHCardio2Mono4.ar(in1,  // return the Ugen with the b-format channels
+			^HOABeamHCardio2Mono4.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -73,7 +73,7 @@ HOABeamHCard2Mono{
 			^[ in1]
 
 			/*
-			^FaustHOABeamHCardio2Mono5.ar(in1,  // return the Ugen with the b-format channels
+			^HOABeamHCardio2Mono5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,

--- a/classes/HOAConvert.sc
+++ b/classes/HOAConvert.sc
@@ -15,34 +15,155 @@ HOAConvert{
 		{ "not a proper output format. \n choose from \\ACN_N3D \\ACN_SN3D or \\FuMa. \n Returning b-format as is.".postln; unconverted = 1; };
 
 		case{order == 1}
-                		{ var in1, // declare variables for the b-format array
+		{
+			case{inputFormat == 1 && outputFormat == 2}
+			{var in1, // declare variables for the b-format array
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			case{unconverted == 0}
-			            {  ^FaustHOAConverter1.ar(in1, // return the Ugen with the b-format channels
-				                                            in2, in3, in4,
-				                                            inputFormat, outputFormat)} // and with the args from the *ar method
+				case{unconverted == 0}
+				{  ^HOAConverterAcnN3d2AcnSn3d1.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4)} // and with the args from the *ar method
 		                { ^[in1, in2, in3, in4] };
-		                }
+			}
+			{inputFormat == 1 && outputFormat == 3}
+			{var in1, // declare variables for the b-format array
+			                    in2, in3, in4;
+                               #in1, // distribute the channels from the array
+			                     in2, in3, in4 = in;
+				case{unconverted == 0}
+				{  ^HOAConverterAcnN3d2FuMa1.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4] };
+			}
+			{inputFormat == 2 && outputFormat == 1}
+			{var in1, // declare variables for the b-format array
+			                    in2, in3, in4;
+                               #in1, // distribute the channels from the array
+			                     in2, in3, in4 = in;
+				case{unconverted == 0}
+				{  ^HOAConverterAcnSn3d2AcnN3d1.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4] };
+			}
+			{inputFormat == 2 && outputFormat == 3}
+			{var in1, // declare variables for the b-format array
+			                    in2, in3, in4;
+                               #in1, // distribute the channels from the array
+			                     in2, in3, in4 = in;
+				case{unconverted == 0}
+				{  ^HOAConverterAcnSn3d2FuMa1.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4] };
+			}
+			{inputFormat == 3 && outputFormat == 1}
+			{var in1, // declare variables for the b-format array
+			                    in2, in3, in4;
+                               #in1, // distribute the channels from the array
+			                     in2, in3, in4 = in;
+				case{unconverted == 0}
+				{  ^HOAConverterFuma2AcnN3d1.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4] };
+			}
+			{inputFormat == 3 && outputFormat == 2}
+			{var in1, // declare variables for the b-format array
+			                    in2, in3, in4;
+                               #in1, // distribute the channels from the array
+			                     in2, in3, in4 = in;
+				case{unconverted == 0}
+				{  ^HOAConverterFuma2AcnSn3d1.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4] };
+			}
+		}
 
-		       {order == 2}
-                		{var in1, // declare variables for the b-format array
+		{order == 2}
+		{
+			case{inputFormat == 1 && outputFormat == 2}
+			{var in1, // declare variables for the b-format array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9;
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			case{unconverted == 0}
-			            {    ^FaustHOAConverter2.ar(in1, // return the Ugen with the b-format channels
+				case{unconverted == 0}
+				{    ^HOAConverterAcnN3d2AcnSn3d2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
-				                                            in5, in6, in7, in8, in9,
-				                                            inputFormat, outputFormat)} // and with the args from the *ar method
-		                { ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9] };
-		                }
+				                                            in5, in6, in7, in8, in9)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9] };
+			}
+			{inputFormat == 1 && outputFormat == 3}
+			{var in1, // declare variables for the b-format array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9;
+                             #in1, // distribute the channels from the array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterAcnN3d2FuMa2.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4,
+				                                            in5, in6, in7, in8, in9)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9] };
+			}
+			{inputFormat == 2 && outputFormat == 1}
+			{var in1, // declare variables for the b-format array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9;
+                             #in1, // distribute the channels from the array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterAcnSn3dAcnN3d2.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4,
+				                                            in5, in6, in7, in8, in9)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9] };
+			}
+			{inputFormat == 2 && outputFormat == 3}
+			{var in1, // declare variables for the b-format array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9;
+                             #in1, // distribute the channels from the array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterAcnSn3d2FuMa2.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4,
+				                                            in5, in6, in7, in8, in9)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9] };
+			}
+			{inputFormat == 3 && outputFormat == 1}
+			{var in1, // declare variables for the b-format array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9;
+                             #in1, // distribute the channels from the array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterFuma2AcnN3d2.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4,
+				                                            in5, in6, in7, in8, in9)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9] };
+			}
+			{inputFormat == 3 && outputFormat == 2}
+			{var in1, // declare variables for the b-format array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9;
+                             #in1, // distribute the channels from the array
+			                   in2, in3, in4,
+			                   in5, in6, in7, in8, in9 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterFuma2AcnSn3d2.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4,
+				                                            in5, in6, in7, in8, in9)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9] };
+			}
+		}
 
-		      {order == 3}
-                		{var in1, // declare variables for the b-format array
+		{order == 3}
+		{
+			case{inputFormat == 1 && outputFormat == 2}
+			{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
 			                   in5,   in6,   in7,   in8,   in9,
 			                   in10, in11, in12, in13, in14, in15, in16;
@@ -50,14 +171,100 @@ HOAConvert{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			case{unconverted == 0}
-                        {    ^FaustHOAConverter3.ar(in1,  // return the Ugen with the b-format channels
+				case{unconverted == 0}
+				{    ^HOAConverterAcnN3d2AcnSn3d3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
-				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           inputFormat, outputFormat)} // and with the args from the *ar method
-		                { ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14, in15, in16] };
-		                }
+				                                           in10, in11, in12, in13, in14,
+				                                           in15, in16)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14, in15, in16] };
+			}
+			{inputFormat == 1 && outputFormat == 3}
+			{var in1, // declare variables for the b-format array
+			                   in2,   in3,   in4,
+			                   in5,   in6,   in7,   in8,   in9,
+			                   in10, in11, in12, in13, in14, in15, in16;
+                              #in1, // distribute the channels from the array
+			                    in2, in3, in4,
+			                    in5, in6, in7, in8, in9,
+			                    in10, in11, in12, in13, in14, in15, in16 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterAcnN3d2FuMa3.ar(in1,  // return the Ugen with the b-format channels
+				                                           in2, in3, in4,
+				                                           in5, in6, in7, in8, in9,
+				                                           in10, in11, in12, in13, in14,
+				                                           in15, in16)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14, in15, in16] };
+			}
+			{inputFormat == 2 && outputFormat == 1}
+			{var in1, // declare variables for the b-format array
+			                   in2,   in3,   in4,
+			                   in5,   in6,   in7,   in8,   in9,
+			                   in10, in11, in12, in13, in14, in15, in16;
+                              #in1, // distribute the channels from the array
+			                    in2, in3, in4,
+			                    in5, in6, in7, in8, in9,
+			                    in10, in11, in12, in13, in14, in15, in16 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterAcnSn3d2AcnN3d3.ar(in1,  // return the Ugen with the b-format channels
+				                                           in2, in3, in4,
+				                                           in5, in6, in7, in8, in9,
+				                                           in10, in11, in12, in13, in14,
+				                                           in15, in16)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14, in15, in16] };
+			}
+			{inputFormat == 2 && outputFormat == 3}
+			{var in1, // declare variables for the b-format array
+			                   in2,   in3,   in4,
+			                   in5,   in6,   in7,   in8,   in9,
+			                   in10, in11, in12, in13, in14, in15, in16;
+                              #in1, // distribute the channels from the array
+			                    in2, in3, in4,
+			                    in5, in6, in7, in8, in9,
+			                    in10, in11, in12, in13, in14, in15, in16 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterAcnSn3d2FuMa3.ar(in1,  // return the Ugen with the b-format channels
+				                                           in2, in3, in4,
+				                                           in5, in6, in7, in8, in9,
+				                                           in10, in11, in12, in13, in14,
+				                                           in15, in16)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14, in15, in16] };
+			}
+			{inputFormat == 3 && outputFormat == 1}
+			{var in1, // declare variables for the b-format array
+			                   in2,   in3,   in4,
+			                   in5,   in6,   in7,   in8,   in9,
+			                   in10, in11, in12, in13, in14, in15, in16;
+                              #in1, // distribute the channels from the array
+			                    in2, in3, in4,
+			                    in5, in6, in7, in8, in9,
+			                    in10, in11, in12, in13, in14, in15, in16 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterFuma2AcnN3d3.ar(in1,  // return the Ugen with the b-format channels
+				                                           in2, in3, in4,
+				                                           in5, in6, in7, in8, in9,
+				                                           in10, in11, in12, in13, in14,
+				                                           in15, in16)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14, in15, in16] };
+			}
+			{inputFormat == 3 && outputFormat == 2}
+			{var in1, // declare variables for the b-format array
+			                   in2,   in3,   in4,
+			                   in5,   in6,   in7,   in8,   in9,
+			                   in10, in11, in12, in13, in14, in15, in16;
+                              #in1, // distribute the channels from the array
+			                    in2, in3, in4,
+			                    in5, in6, in7, in8, in9,
+			                    in10, in11, in12, in13, in14, in15, in16 = in;
+				case{unconverted == 0}
+				{    ^HOAConverterFuma2AcnSn3d3.ar(in1,  // return the Ugen with the b-format channels
+				                                           in2, in3, in4,
+				                                           in5, in6, in7, in8, in9,
+				                                           in10, in11, in12, in13, in14,
+				                                           in15, in16)} // and with the args from the *ar method
+				{ ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14, in15, in16] };
+			}
+		}
 
 		  {order == 4}
                 		{var in1, // declare variables for the b-format array
@@ -71,15 +278,24 @@ HOAConvert{
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25 = in;
 
+			"order 4 is not implemented for HOAConvert,\n returning unconverted
+bformat.".postln;
+			^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14,
+				in15, in16 ]
+			/*
 	             case{unconverted == 0}
-                        {    ^FaustHOAConverter4.ar(in1,  // return the Ugen with the b-format channels
+                        {    ^HOAConverter4.ar(in1,  // return the Ugen with the b-format
+		channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
-				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25,
-				                                           inputFormat, outputFormat)  } // and with the args from the *ar method
-					                { ^[in1, in2, in3, in4,  in5, in6, in7, in8, in9,  in10, in11, in12, in13, in14, in15, in16] };
-		                }
+				                                           in10, in11, in12, in13, in14, in15,
+			                                               in16, in17, in18, in19, in20, in21,
+			                                               in22, in23, in24, in25,
+				                                           inputFormat, outputFormat)
+			} // and with the args from the *ar method
+		*/
+		}
+
                {order == 5}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -96,7 +312,7 @@ HOAConvert{
 			"order 5 is not implemented for HOAConvert,\n returning unconverted bformat.".postln;
 			^[ in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 ]
 		/*
-			^FaustHOAConverter5.ar(in1,  // return the Ugen with the b-format channels
+			^HOAConverter5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,

--- a/classes/HOADec5_0.sc
+++ b/classes/HOADec5_0.sc
@@ -8,7 +8,7 @@ HOADec5_0{
 			                    in2, in3, in4, decoded;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^FaustITU5001.ar(in1, // return the Ugen
+			              ^ITU5001.ar(in1, // return the Ugen
 				                                            in2, in3, in4,
 				                                            gain: gain.ampdb, lf_hf: lf_hf, mute:mute, xover:xover );
 
@@ -20,7 +20,7 @@ HOADec5_0{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^FaustITU5002.ar(in1,
+			              ^ITU5002.ar(in1,
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
 				                                            gain: gain.ampdb, lf_hf: lf_hf, mute:mute, xover:xover );
@@ -35,7 +35,7 @@ HOADec5_0{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^FaustITU5003.ar(in1,  // return the Ugen
+			             ^ITU5003.ar(in1,  // return the Ugen
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -55,7 +55,7 @@ HOADec5_0{
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25 = in;
-			             ^FaustITU5004.ar(in1,  // return the Ugen
+			             ^ITU5004.ar(in1,  // return the Ugen
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,

--- a/classes/HOADecLebedev.sc
+++ b/classes/HOADecLebedev.sc
@@ -67,7 +67,7 @@ HOADecLebedev {
 
 		decoded = switch(order.asInt,
 			1, {
-				FaustHOADecLebedev061.ar(
+				HOADecLebedev061.ar(
 					in[0], in[1], in[2], in[3],
 					inputs_gain: input_gains,
 					outputs_gain: output_gains,
@@ -76,7 +76,7 @@ HOADecLebedev {
 				);
 			},
 			2, {
-				FaustHOADecLebedev262.ar(
+				HOADecLebedev262.ar(
 					in[0], in[1], in[2], in[3], in[4],
 					in[5], in[6], in[7], in[8],
 					inputs_gain: input_gains,
@@ -86,7 +86,7 @@ HOADecLebedev {
 				);
 			},
 			3, {
-				FaustHOADecLebedev263.ar(
+				HOADecLebedev263.ar(
 					in[ 0], in[ 1], in[ 2], in[ 3],
 					in[ 4], in[ 5], in[ 6], in[ 7],
 					in[ 8], in[ 9], in[10], in[11],

--- a/classes/HOADecLebedev50.sc
+++ b/classes/HOADecLebedev50.sc
@@ -26,7 +26,7 @@ HOADecLebedev50 : HOADecLebedev {
 
 		decoded = switch(order,
 			1, {
-				FaustHOADecLebedev501.ar(
+				HOADecLebedev501.ar(
 					in[0], in[1], in[2], in[3],
 					inputs_gain: input_gains,
 					outputs_gain: output_gains,
@@ -35,7 +35,7 @@ HOADecLebedev50 : HOADecLebedev {
 				);
 			},
 			2, {
-				FaustHOADecLebedev502.ar(
+				HOADecLebedev502.ar(
 					in[0], in[1], in[2], in[3], in[4],
 					in[5], in[6], in[7], in[8],
 					inputs_gain: input_gains,
@@ -45,7 +45,7 @@ HOADecLebedev50 : HOADecLebedev {
 				)
 			},
 			3, {
-				FaustHOADecLebedev503.ar(
+				HOADecLebedev503.ar(
 					in[ 0], in[ 1], in[ 2], in[ 3],
 					in[ 4], in[ 5], in[ 6], in[ 7],
 					in[ 8], in[ 9], in[10], in[11],
@@ -57,7 +57,7 @@ HOADecLebedev50 : HOADecLebedev {
 				)
 			},
 			4, {
-				FaustHOADecLebedev504.ar(
+				HOADecLebedev504.ar(
 					in[ 0], in[ 1], in[ 2], in[ 3],
 					in[ 4], in[ 5], in[ 6], in[ 7],
 					in[ 8], in[ 9], in[10], in[11],
@@ -71,7 +71,7 @@ HOADecLebedev50 : HOADecLebedev {
 				)
 			},
 			5, {
-				FaustHOADecLebedev505.ar(
+				HOADecLebedev505.ar(
 					in[ 0], in[ 1], in[ 2], in[ 3],
 					in[ 4], in[ 5], in[ 6], in[ 7],
 					in[ 8], in[ 9], in[10], in[11],

--- a/classes/HOAEncEigenMike.sc
+++ b/classes/HOAEncEigenMike.sc
@@ -23,7 +23,7 @@ HOAEncEigenMike{
 			                    in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 			                    in31, in32 = in;
 
-			                    encoded= FaustHOAEncEigenMike1.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncEigenMike1.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32,
@@ -53,7 +53,7 @@ HOAEncEigenMike{
 			                    in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 			                    in31, in32 = in;
 
-			                    encoded= FaustHOAEncEigenMike2.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncEigenMike2.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32,
@@ -88,7 +88,7 @@ HOAEncEigenMike{
 			                    in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 			                    in31, in32 = in;
 
-                                encoded= FaustHOAEncEigenMike3.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+                                encoded= HOAEncEigenMike3.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32,
@@ -130,7 +130,7 @@ HOAEncEigenMike{
 			                    in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 			                    in31, in32 = in;
 
-			                    encoded= FaustHOAEncEigenMike4.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncEigenMike4.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32,

--- a/classes/HOAEncLebedev06.sc
+++ b/classes/HOAEncLebedev06.sc
@@ -13,7 +13,7 @@ HOAEncLebedev06{
 
                               #in1, in2, in3, in4, in5, in6 = in;
 
-			                    encoded= FaustHOAEncLebedev061.ar(in1, in2, in3, in4, in5, in6,
+			                    encoded= HOAEncLebedev061.ar(in1, in2, in3, in4, in5, in6,
 				                                                                      gain:gain);
 
 			if(filters == 0,

--- a/classes/HOAEncLebedev26.sc
+++ b/classes/HOAEncLebedev26.sc
@@ -19,7 +19,7 @@ HOAEncLebedev26{
 			                    in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 			                    in21, in22, in23, in24, in25, in26 = in;
 
-			                    encoded= FaustHOAEncLebedev261.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncLebedev261.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26,
 				                                                                      gain: gain);
@@ -48,7 +48,7 @@ HOAEncLebedev26{
 			                    in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 			                    in21, in22, in23, in24, in25, in26 = in;
 
-			                    encoded= FaustHOAEncLebedev262.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncLebedev262.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26,
 				                                                                      gain: gain);
@@ -83,7 +83,7 @@ HOAEncLebedev26{
 			                    in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 			                    in21, in22, in23, in24, in25, in26 = in;
 
-			                    encoded= FaustHOAEncLebedev263.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncLebedev263.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26,
 				                                                                      gain: gain);

--- a/classes/HOAEncLebedev50.sc
+++ b/classes/HOAEncLebedev50.sc
@@ -26,7 +26,7 @@ HOAEncLebedev50{
 			                    in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
 			                    in41, in42, in43, in44, in45, in46, in47, in48, in49, in50 = in;
 
-			                    encoded= FaustHOAEncLebedev501.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncLebedev501.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
@@ -60,7 +60,7 @@ HOAEncLebedev50{
 			                    in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
 			                    in41, in42, in43, in44, in45, in46, in47, in48, in49, in50 = in;
 
-			                    encoded= FaustHOAEncLebedev502.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncLebedev502.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
@@ -99,7 +99,7 @@ HOAEncLebedev50{
 			                    in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
 			                    in41, in42, in43, in44, in45, in46, in47, in48, in49, in50 = in;
 
-			                    encoded= FaustHOAEncLebedev503.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncLebedev503.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
@@ -145,7 +145,7 @@ HOAEncLebedev50{
 			                    in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
 			                    in41, in42, in43, in44, in45, in46, in47, in48, in49, in50 = in;
 
-			                    encoded= FaustHOAEncLebedev504.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncLebedev504.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
@@ -200,7 +200,7 @@ HOAEncLebedev50{
 			                    in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,
 			                    in41, in42, in43, in44, in45, in46, in47, in48, in49, in50 = in;
 
-			                    encoded= FaustHOAEncLebedev505.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
+			                    encoded= HOAEncLebedev505.ar(in1, in2, in3, in4, in5, in6, in7, in8, in9, in10,
 				                                                                      in11, in12, in13, in14, in15, in16, in17, in18, in19, in20,
 				                                                                      in21, in22, in23, in24, in25, in26, in27, in28, in29, in30,
 				                                                                      in31, in32, in33, in34, in35, in36, in37, in38, in39, in40,

--- a/classes/HOAEncoder.sc
+++ b/classes/HOAEncoder.sc
@@ -1,15 +1,15 @@
 HOAEncoder{
 	*ar { |order, in, az=0, elev = 0, gain=0, plane_spherical = 0, radius=2, speaker_radius=1.07|
 		case{order == 1}
-		               {^FaustHOAEncoder1.ar( in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius )}
+		               {^HOAEncoder1.ar( in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius )}
 		       {order == 2}
-                		{^FaustHOAEncoder2.ar(in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius)}
+                		{^HOAEncoder2.ar(in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius)}
                {order == 3}
-                		{^FaustHOAEncoder3.ar(in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius)}
+                		{^HOAEncoder3.ar(in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius)}
                {order == 4}
-                		{^FaustHOAEncoder4.ar(in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius)}
+                		{^HOAEncoder4.ar(in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius)}
                {order == 5}
-                		{^FaustHOAEncoder5.ar(in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius)}
+                		{^HOAEncoder5.ar(in1:in, gain_0:gain, radius_0:radius, azimuth_0:az, elevation_0:elev, yes:plane_spherical, speaker_radius_0:speaker_radius)}
 		       {"this order is not implemented for HOAEncPan".postln;}
 	}
 }

--- a/classes/HOAMirror.sc
+++ b/classes/HOAMirror.sc
@@ -6,7 +6,7 @@ HOATransMirror{
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^FaustHOAMirror1.ar(in1, // return the Ugen with the b-format channels
+			              ^HOAMirror1.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            front_back, left_right, up_down)} // and with the args from the *ar method
 		       {order == 2}
@@ -16,7 +16,7 @@ HOATransMirror{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^FaustHOAMirror2.ar(in1, // return the Ugen with the b-format channels
+			              ^HOAMirror2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
 				                                            front_back, left_right, up_down)} // and with the args from the *ar method
@@ -29,7 +29,7 @@ HOATransMirror{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^FaustHOAMirror3.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOAMirror3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -45,7 +45,7 @@ HOATransMirror{
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25 = in;
-			             ^FaustHOAMirror4.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOAMirror4.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -64,7 +64,7 @@ HOATransMirror{
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25,
 			                    in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 = in;
-			             ^FaustHOAMirror5.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOAMirror5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,

--- a/classes/HOATransRotateAz.sc
+++ b/classes/HOATransRotateAz.sc
@@ -6,7 +6,7 @@ HOATransRotateAz{
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^FaustHOAAzimuthRotator1.ar(in1, // return the Ugen with the b-format channels
+			              ^HOAAzimuthRotator1.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            az)} // and with the args from the *ar method
 		       {order == 2}
@@ -16,7 +16,7 @@ HOATransRotateAz{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^FaustHOAAzimuthRotator2.ar(in1, // return the Ugen with the b-format channels
+			              ^HOAAzimuthRotator2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
 				                                            az)} // and with the args from the *ar method
@@ -29,7 +29,7 @@ HOATransRotateAz{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^FaustHOAAzimuthRotator3.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOAAzimuthRotator3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -45,7 +45,7 @@ HOATransRotateAz{
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25 = in;
-			             ^FaustHOAAzimuthRotator4.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOAAzimuthRotator4.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -64,7 +64,7 @@ HOATransRotateAz{
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25,
 			                    in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 = in;
-			             ^FaustHOAAzimuthRotator5.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOAAzimuthRotator5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,

--- a/classes/HOATransRotateXYZ.sc
+++ b/classes/HOATransRotateXYZ.sc
@@ -6,7 +6,7 @@ HOATransRotateXYZ{
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^FaustHOARotator1.ar(in1, // return the Ugen with the b-format channels
+			              ^HOARotator1.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            pitch, roll, yaw)} // and with the args from the *ar method
 		       {order == 2}
@@ -16,7 +16,7 @@ HOATransRotateXYZ{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^FaustHOARotator2.ar(in1, // return the Ugen with the b-format channels
+			              ^HOARotator2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
 				                                            pitch, roll, yaw)} // and with the args from the *ar method
@@ -29,7 +29,7 @@ HOATransRotateXYZ{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^FaustHOARotator3.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOARotator3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -48,7 +48,7 @@ HOATransRotateXYZ{
 			"order 4 is not implemented for HOATransRotateXYZ. \n returning unrotated bformat.".postln;
 			^[ in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25 ]
 			/*
-			             ^FaustHOAAzimuthRotator4.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOAAzimuthRotator4.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
@@ -71,7 +71,7 @@ HOATransRotateXYZ{
 			                    in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 = in;
 			"order 5 is not implemented for HOATransRotateXYZ,\n returning unrotated bformat.".postln;
 			^[ in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 ]
-			/*             ^FaustHOAAzimuthRotator5.ar(in1,  // return the Ugen with the b-format channels
+			/*             ^HOAAzimuthRotator5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,

--- a/tests/HOADecLebedev_tests.scd
+++ b/tests/HOADecLebedev_tests.scd
@@ -22,8 +22,8 @@ s.options
 
 // initialise everything for the tests
 s.doWhenBooted{
-	HOADecLebedev26.loadHrirFilters(s, "/localvol/sound/src/ambitools/FIR/hrir/hrir_christophe_lebedev50");
-	HOADecLebedev06.loadHrirFilters(s, "/localvol/sound/src/ambitools/FIR/hrir/hrir_christophe_lebedev50");
+	HOADecLebedev26.loadHrirFilters(s, "~/Documents/repos/ambitools/FIR/hrir/hrir_christophe_lebedev50");
+	HOADecLebedev06.loadHrirFilters(s, "~/Documents/repos/ambitools/FIR/hrir/hrir_christophe_lebedev50");
 	~order = 4;
 	~hoaNumChannels = (~order+1).pow(2);
 


### PR DESCRIPTION
The HOAconvert class needed to be changed as well to match the Ugens.
In dooing so I noticeed that there are not yet any HOAConvertAcnSn3d2AcnN3d of any order.
