### PR TITLE
Add missing caret return

### DIFF
--- a/classes/HOA.sc
+++ b/classes/HOA.sc
@@ -22,17 +22,17 @@ HOA {
 
 
 	*userSoundsDir {
-		userSupportDir +/+ soundsSubdir;
+		^userSupportDir +/+ soundsSubdir
 	}
 	*systemSoundsDir {
-		systemSupportDir +/+ soundsSubdir;
+		^systemSupportDir +/+ soundsSubdir
 	}
 
 	*userKernelDir {
-		userSupportDir +/+ kernelSubdir;
+		^userSupportDir +/+ kernelSubdir
 	}
 	*systemKernelDir {
-		systemSupportDir +/+ kernelSubdir;
+		^systemSupportDir +/+ kernelSubdir
 	}
 
 	*openUserSupportDir {


### PR DESCRIPTION
In SC, If a method doesn't return a value explicitly, the object is returned. I also removed the semi-colons for good styling.