### PR TITLE
sudo-Ugens and Helpfiles to reflect added features in HOAUgens

### DIFF
--- a/HelpSource/Classes/HOABeamDirac2Hoa.schelp
+++ b/HelpSource/Classes/HOABeamDirac2Hoa.schelp
@@ -1,16 +1,20 @@
 TITLE:: HOABeamDirac2Hoa
-summary:: Mirroring of a higher order Ambisonics sound field
+summary:: dirrectional filtering of a higher order Ambisonic sound field
 categories:: Libraries>HOA
-related:: Guides/HOAguide, Tutorials/HOA_Tutorial_Overview
+related:: Guides/HOAguide, Tutorials/HOA_Tutorial_Overview, HOABeamHCard2Hoa
 
 DESCRIPTION::
-(put long description here)
+dirrectional filtering of a higher order Ambisonic sound field
 
 
 CLASSMETHODS::
 
 METHOD:: ar
 pseudo Ugen method returning Ugens based on Ambisonics order provided through the first argument.
+
+ARGUMENT:: timer_man
+0: timmer mode to crossfade durring the time sepcified by "crossfade" when "on" is switched.
+1: manual mode to manually crossfade according to the "focus" argument (default: plane).
 
 ARGUMENT:: order
 Ambisonics order 1-5.
@@ -28,10 +32,15 @@ ARGUMENT:: level
 level in dB (default 0).
 
 ARGUMENT:: on
-(describe argument here)
+0: no dirrectionnal filtering applied. 1: apply dirrectional filtering
+(only relevant if timer_man is set to 0)
 
 ARGUMENT:: crossfade
-(describe argument here)
+crossfade time in seconds from 0.1 to 10 between filtered and unfiltered signal wen "on" is switched (only relevant if timer_man is set to 0).
+
+ARGUMENT:: focus
+manualy crossfade from 0 to 1 between no dirrectional filtering and fully filtered signal.
+(only relevant if timer_man is set to 1)
 
 returns:: b-format as channel array.
 

--- a/HelpSource/Classes/HOABeamHCard2Hoa.schelp
+++ b/HelpSource/Classes/HOABeamHCard2Hoa.schelp
@@ -1,10 +1,10 @@
 TITLE:: HOABeamHCard2Hoa
-summary:: Mirroring of a higher order Ambisonics sound field
+summary:: dirrectional filtering of a higher order Ambisonic sound field
 categories:: Libraries>HOA
-related:: Guides/HOAguide, Tutorials/HOA_Tutorial_Overview
+related:: Guides/HOAguide, Tutorials/HOA_Tutorial_Overview, HOABeamDirac2Hoa, HOABeamHCard2Mono
 
 DESCRIPTION::
-(put long description here)
+dirrectional filtering of a higher order Ambisonic sound field
 
 
 CLASSMETHODS::
@@ -24,14 +24,12 @@ azimuth angle of beam direction in degree (-pi to pi).
 ARGUMENT:: ele
 elevation angle of beam direction in degree (-pi * 0.5 to pi * 0.5).
 
-ARGUMENT:: level
-level in dB (default 0).
+ARGUMENT:: int_float
+0: "cardOrder" integer step from 0 (omni) up to "order".
+1: float interpolation between "cardOrder" steps.
 
-ARGUMENT:: on
-(describe argument here)
-
-ARGUMENT:: crossfade
-(describe argument here)
+ARGUMENT:: cardOrder
+cardioïde shape from 0 (omni) up to "order".
 
 returns:: b-format as channel array.
 

--- a/HelpSource/Classes/HOABeamHCard2Mono.schelp
+++ b/HelpSource/Classes/HOABeamHCard2Mono.schelp
@@ -1,11 +1,10 @@
 TITLE:: HOABeamHCard2Mono
-summary:: Mirroring of a higher order Ambisonics sound field
+summary:: dirrectional filtering of a higher order Ambisonic sound field
 categories:: Libraries>HOA
-related:: Guides/HOAguide, Tutorials/HOA_Tutorial_Overview
+related:: Guides/HOAguide, Tutorials/HOA_Tutorial_Overview, HOABeamHCard2Hoa
 
 DESCRIPTION::
-(put long description here)
-
+dirrectional filtering of a higher order Ambisonic sound field rendered to mono.
 
 CLASSMETHODS::
 
@@ -24,14 +23,15 @@ azimuth angle of beam direction in degree (-pi to pi).
 ARGUMENT:: ele
 elevation angle of beam direction in degree (-pi * 0.5 to pi * 0.5).
 
+ARGUMENT:: int_float
+0: "cardOrder" integer step from 0 (omni) up to "order".
+1: float interpolation between "cardOrder" steps.
+
+ARGUMENT:: cardOrder
+cardioïde shape from 0 (omni) up to "order".
+
 ARGUMENT:: gain
 level in dB (default 0).
-
-ARGUMENT:: on
-(describe argument here)
-
-ARGUMENT:: crossfade
-(describe argument here)
 
 returns:: mono signal
 

--- a/HelpSource/Classes/HOALibEnc3D.schelp
+++ b/HelpSource/Classes/HOALibEnc3D.schelp
@@ -1,0 +1,58 @@
+TITLE:: HOALibEnc3D
+summary:: Light wheight, plane wave alternative to HOAEcoder
+categories:: Libraries>HOA
+related:: HOAEncoder, HOAmbiPanner
+
+DESCRIPTION::
+HOALibEnc3D pans mono sound sources in a higher order Ambisonics sound field.
+
+Adapted from https://github.com/CICM/HoaLibrary-Faust
+the Faust implementation of CICM's HoaLib http://hoalibrary.mshparisnord.fr/en
+
+
+CLASSMETHODS::
+
+METHOD:: ar
+pseudo Ugen method returning Ugens based on Ambisonics order provided through the first argument.
+
+ARGUMENT:: order
+Ambisonics order 1-5.
+
+ARGUMENT:: in
+b-format as channel array.
+
+ARGUMENT:: az
+azimuth in degree -pi to pi.
+
+ARGUMENT:: elev
+elevation in degree -pi/2 to pi/2
+
+ARGUMENT:: gain
+in dB
+
+returns:: returns encoded HOA scene (4,9,16,25,36 channels depending on the order argument).
+
+INSTANCEMETHODS::
+
+EXAMPLES::
+
+code::
+(
+Server.local = Server.default;
+o = Server.local.options;
+o.numInputBusChannels = 1;
+o.numOutputBusChannels = 36;
+o.numAudioBusChannels = 2048 * 8;
+o.blockSize = 512 ;
+o.numWireBufs = 1024;
+o.sampleRate = 48000;
+s.makeWindow;
+s.boot;
+)
+
+// Rotate an audio scene around pitch yaw and roll
+( ~order = 2; // try different orders up to 5 and watch the scope window.
+s.scope((~order+1).pow(2));
+{HOALibEnc3D.ar(~order, WhiteNoise.ar(1), MouseX.kr(0, 360), MouseY.kr(-90, 90 ) )}.play;
+)
+::

--- a/HelpSource/Classes/HOALibOptim.schelp
+++ b/HelpSource/Classes/HOALibOptim.schelp
@@ -1,0 +1,48 @@
+TITLE:: HOALibOptim
+summary:: Converting of a higher order Ambisonics b-format
+categories:: Libraries>HOA
+related:: HOAEncoder, HOALibEnc3D
+
+DESCRIPTION::
+Pseudo Ugen method returning Ugens for the optimisation of HOA b-formats.
+
+Adapted from https://github.com/CICM/HoaLibrary-Faust
+the Faust implementation of CICM's HoaLib http://hoalibrary.mshparisnord.fr/en
+
+CLASSMETHODS::
+
+METHOD:: ar
+ARGUMENT:: order
+Ambisonics order 1-5.
+
+ARGUMENT:: in
+b-format as channel array.
+
+argument:: inPhase_MaxRE
+0: InPhase optimisation 1: MaxRe optimisation
+
+INSTANCEMETHODS::
+
+
+EXAMPLES::
+
+code::
+(
+Server.local = Server.default;
+o = Server.local.options;
+o.numInputBusChannels = 1;
+o.numOutputBusChannels = 36;
+o.numAudioBusChannels = 2048 * 8;
+o.blockSize = 512 ;
+o.numWireBufs = 1024;
+o.sampleRate = 48000;
+s.makeWindow;
+s.boot;
+)
+
+( s.scope((~order+1).pow(2));
+{ HOALibOptim.ar(~order,  HOAEncoder.ar(~order, WhiteNoise.ar(1.0)), 0 ) }.play )
+
+( s.scope((~order+1).pow(2));
+{ HOALibOptim.ar(~order,  HOAEncoder.ar(~order, WhiteNoise.ar(1.0)), 1 ) }.play )
+::

--- a/HelpSource/Classes/HOAmbiPanner.schelp
+++ b/HelpSource/Classes/HOAmbiPanner.schelp
@@ -1,0 +1,61 @@
+TITLE:: HOAmbiPanner
+summary:: Light wheight, plane wave alternative to HOAEcoder
+categories:: Libraries>HOA
+related:: HOAEncoder, HOAAmbiDecoderHelper
+
+DESCRIPTION::
+HOAmbiPanner pans mono sound sources in a higher order Ambisonics sound field.
+
+Adapted from https://bitbucket.org/ambidecodertoolbox/adt/src/b6c8c11dc421e7b6a1261b03872788bbd7a8fee7/faust/ambi_panner_ambix_o5.dsp?at=master&fileviewer=file-view-default
+the Faust encoder provided by Aaron Heller's ambidecodertoolbox https://bitbucket.org/ambidecodertoolbox/adt.git
+otherwise used for creating higher order Ambisonic decoders.
+SC-HOA provides the HOAAmbiDecoderHelper class for creaing encoders using ambidecodertoolbox
+
+
+
+CLASSMETHODS::
+
+METHOD:: ar
+pseudo Ugen method returning Ugens based on Ambisonics order provided through the first argument.
+
+ARGUMENT:: order
+Ambisonics order 1-5.
+
+ARGUMENT:: in
+b-format as channel array.
+
+ARGUMENT:: az
+azimuth in degree -pi to pi.
+
+ARGUMENT:: elev
+elevation in degree -pi/2 to pi/2
+
+ARGUMENT:: gain
+in dB
+
+returns:: returns encoded HOA scene (4,9,16,25,36 channels depending on the order argument).
+
+INSTANCEMETHODS::
+
+EXAMPLES::
+
+code::
+(
+Server.local = Server.default;
+o = Server.local.options;
+o.numInputBusChannels = 1;
+o.numOutputBusChannels = 36;
+o.numAudioBusChannels = 2048 * 8;
+o.blockSize = 512 ;
+o.numWireBufs = 1024;
+o.sampleRate = 48000;
+s.makeWindow;
+s.boot;
+)
+
+// Rotate an audio scene around pitch yaw and roll
+( ~order = 2; // try different orders up to 5 and watch the scope window.
+s.scope((~order+1).pow(2));
+{HOAmbiPanner.ar(~order, WhiteNoise.ar(1), MouseX.kr(0, 360), MouseY.kr(-90, 90 ) )}.play;
+)
+::

--- a/classes/HOALibEnc3D.sc
+++ b/classes/HOALibEnc3D.sc
@@ -1,0 +1,16 @@
+HOALibEnc3D{
+	*ar { |order=1, in, az=0, elev = 0, gain=0|
+		case
+		{order == 1}
+		{^HOALibEnc3D1.ar( in1:in, azi:az, ele:elev )  * gain.dbamp}
+		       {order == 2}
+		{^HOALibEnc3D2.ar( in1:in, azi:az, ele:elev )  * gain.dbamp}
+               {order == 3}
+		{^HOALibEnc3D3.ar( in1:in, azi:az, ele:elev )  * gain.dbamp}
+               {order == 4}
+		{^HOALibEnc3D4.ar( in1:in, azi:az, ele:elev ) * gain.dbamp}
+               {order == 5}
+		{^HOALibEnc3D5.ar( in1:in, azi:az, ele:elev )  * gain.dbamp}
+		       {"this order is not implemented for HOALibEnc3D".postln;}
+	}
+}

--- a/classes/HOALibInPhase3D.sc
+++ b/classes/HOALibInPhase3D.sc
@@ -1,16 +1,13 @@
-HOABeamDirac2Hoa{
+HOALibInPhase3D{
 
-	*ar { |order, in, timer_man=0, az=0, ele=0, level=0, on=0, crossfade=1, focus=0|
-		// az = az * -1; ele = ele * -1;  // the Faust Ugens seem to have those reversed
+	*ar { |order, in|
 		case{order == 1}
                 		{ var in1, // declare variables for the b-format array
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^HOABeamDirac2HOA1.ar(in1,// return the Ugen with the b-format channels
-				                                            in2, in3, in4, timer_manual:timer_man,
-				                                            azimuth:az, elevation:ele, gain:level,
-				on:on, crossfade:crossfade, focus:focus)} // and with the args from the *ar method
+			              ^HOALibInPhase3D1.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4)} // and with the args from the *ar method
 		       {order == 2}
                 		{var in1, // declare variables for the b-format array
 			                   in2, in3, in4,
@@ -18,12 +15,9 @@ HOABeamDirac2Hoa{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^HOABeamDirac2HOA2.ar(in1, // return the Ugen with the b-format channels
+			              ^HOALibInPhase3D2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
-				                                            in5, in6, in7, in8, in9,
-				                                            timer_manual:timer_man,
-				                                            azimuth:az, elevation:ele, gain:level,
-				on:on, crossfade:crossfade, focus:focus)} // and with the args from the *ar method
+				                                            in5, in6, in7, in8, in9)} // and with the args from the *ar method
                {order == 3}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -33,13 +27,10 @@ HOABeamDirac2Hoa{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^HOABeamDirac2HOA3.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOALibInPhase3D3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
-				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           timer_manual:timer_man, azimuth:az,
-				elevation:ele, gain:level, on: on, crossfade:crossfade, focus:focus)}
-		        // and with the args from the *ar method
+				                                           in10, in11, in12, in13, in14, in15, in16)} // and with the args from the *ar method
                {order == 4}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -51,14 +42,11 @@ HOABeamDirac2Hoa{
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25 = in;
-			             ^HOABeamDirac2HOA4.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOALibInPhase3D4.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           in17, in18, in19, in20, in21, in22, in23,
-				                                           in24, in25, timer_manual:timer_man,
-				azimuth:az, elevation:ele, gain:level, on:on, crossfade:crossfade, focus:focus)}
-		        // and with the args from the *ar method
+				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25)} // and with the args from the *ar method
                {order == 5}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -72,17 +60,13 @@ HOABeamDirac2Hoa{
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25,
 			                    in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 = in;
-			             ^HOABeamDirac2HOA5.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOALibInPhase3D5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           in17, in18, in19, in20, in21, in22, in23,
-				                                           in24, in25, in26, in27, in28, in29, in30,
-				                                           in31, in32, in33, in34, in35, in36,
-				                                           timer_manual:timer_man, azimuth:az,
-				elevation:ele, gain:level, on:on, crossfade:crossfade, focus:focus)}
-		        // and with the args from the *ar method
-				{"this order is not implemented".postln}
+				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25,
+				                                           in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36)} // and with the args from the *ar method
+				{"this order is not implemented for HOALibInPhase3D".postln}
 	}
 
 }

--- a/classes/HOALibMaxRe3D.sc
+++ b/classes/HOALibMaxRe3D.sc
@@ -1,16 +1,13 @@
-HOABeamDirac2Hoa{
+HOALibMaxRe3D{
 
-	*ar { |order, in, timer_man=0, az=0, ele=0, level=0, on=0, crossfade=1, focus=0|
-		// az = az * -1; ele = ele * -1;  // the Faust Ugens seem to have those reversed
+	*ar { |order, in|
 		case{order == 1}
                 		{ var in1, // declare variables for the b-format array
 			                    in2, in3, in4;
                                #in1, // distribute the channels from the array
 			                     in2, in3, in4 = in;
-			              ^HOABeamDirac2HOA1.ar(in1,// return the Ugen with the b-format channels
-				                                            in2, in3, in4, timer_manual:timer_man,
-				                                            azimuth:az, elevation:ele, gain:level,
-				on:on, crossfade:crossfade, focus:focus)} // and with the args from the *ar method
+			              ^HOALibMaxRe3D1.ar(in1, // return the Ugen with the b-format channels
+				                                            in2, in3, in4)} // and with the args from the *ar method
 		       {order == 2}
                 		{var in1, // declare variables for the b-format array
 			                   in2, in3, in4,
@@ -18,12 +15,9 @@ HOABeamDirac2Hoa{
                              #in1, // distribute the channels from the array
 			                   in2, in3, in4,
 			                   in5, in6, in7, in8, in9 = in;
-			              ^HOABeamDirac2HOA2.ar(in1, // return the Ugen with the b-format channels
+			              ^HOALibMaxRe3D2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
-				                                            in5, in6, in7, in8, in9,
-				                                            timer_manual:timer_man,
-				                                            azimuth:az, elevation:ele, gain:level,
-				on:on, crossfade:crossfade, focus:focus)} // and with the args from the *ar method
+				                                            in5, in6, in7, in8, in9)} // and with the args from the *ar method
                {order == 3}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -33,13 +27,10 @@ HOABeamDirac2Hoa{
 			                    in2, in3, in4,
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^HOABeamDirac2HOA3.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOALibMaxRe3D3.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
-				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           timer_manual:timer_man, azimuth:az,
-				elevation:ele, gain:level, on: on, crossfade:crossfade, focus:focus)}
-		        // and with the args from the *ar method
+				                                           in10, in11, in12, in13, in14, in15, in16)} // and with the args from the *ar method
                {order == 4}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -51,14 +42,11 @@ HOABeamDirac2Hoa{
 			                    in5, in6, in7, in8, in9,
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25 = in;
-			             ^HOABeamDirac2HOA4.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOALibMaxRe3D4.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           in17, in18, in19, in20, in21, in22, in23,
-				                                           in24, in25, timer_manual:timer_man,
-				azimuth:az, elevation:ele, gain:level, on:on, crossfade:crossfade, focus:focus)}
-		        // and with the args from the *ar method
+				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25)} // and with the args from the *ar method
                {order == 5}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -72,17 +60,13 @@ HOABeamDirac2Hoa{
 			                    in10, in11, in12, in13, in14, in15, in16,
 			                    in17, in18, in19, in20, in21, in22, in23, in24, in25,
 			                    in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 = in;
-			             ^HOABeamDirac2HOA5.ar(in1,  // return the Ugen with the b-format channels
+			             ^HOALibMaxRe3D5.ar(in1,  // return the Ugen with the b-format channels
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           in17, in18, in19, in20, in21, in22, in23,
-				                                           in24, in25, in26, in27, in28, in29, in30,
-				                                           in31, in32, in33, in34, in35, in36,
-				                                           timer_manual:timer_man, azimuth:az,
-				elevation:ele, gain:level, on:on, crossfade:crossfade, focus:focus)}
-		        // and with the args from the *ar method
-				{"this order is not implemented".postln}
+				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25,
+				                                           in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36)} // and with the args from the *ar method
+				{"this order is not implemented for HOALibMaxRe3D".postln}
 	}
 
 }

--- a/classes/HOALibOptim.sc
+++ b/classes/HOALibOptim.sc
@@ -1,0 +1,13 @@
+HOALibOptim{
+
+	*ar { |order, in, inPhase_MaxRe|
+
+		// optimize with InPhase
+		case{ (inPhase_MaxRe == 0) }
+			{ ^HOALibInPhase3D.ar(order, in)}
+		// converting with MaxRe
+		    { (inPhase_MaxRe == 1) }
+			{ ^HOALibMaxRe3D.ar(order, in)}
+
+	}
+}

--- a/classes/HOAmbiPanner.sc
+++ b/classes/HOAmbiPanner.sc
@@ -1,0 +1,16 @@
+HOAmbiPanner{
+	*ar { |order=1, in, az=0, elev=0, gain=0|
+		case
+		{order == 1}
+		{^HOAmbiPanner1.ar( in1:in, azi:az, ele:elev ) * gain.dbamp}
+		{order == 2}
+		{^HOAmbiPanner2.ar( in1:in, azi:az, ele:elev ) * gain.dbamp}
+		{order == 3}
+		{^HOAmbiPanner3.ar( in1:in, azi:az, ele:elev ) * gain.dbamp}
+		{order == 4}
+		{^HOAmbiPanner4.ar( in1:in, azi:az, ele:elev ) * gain.dbamp}
+		{order == 5}
+		{^HOAmbiPanner5.ar( in1:in, azi:az, ele:elev ) * gain.dbamp}
+		{"this order is not implemented for AmbiPanner".postln;}
+	}
+}


### PR DESCRIPTION
This PR follows
https://github.com/florian-grond/sc3-pluginsHOA/pull/8

it contains updated versions of the Beamformation sudo-Ugens and Help files as well as the folowing:
     _HOALibEnc3D class and doc for "light weight", plane wave, high order encoding of mono sources
     _HOALibEnc3D class and doc for "light weight", broad sounding, plane wave, high order encoding 
       of mono sources
     _HOALibOptim class and doc for InPhase and MaxRe optimisation of high order ambisonic sound 
       fields

These Classes aim to match closely preexisting uses of the SC-HOA sudo-Ugens.

Help files are still rudimentary but tutorials and updated guide are comming soon. 
