### PR TITLE
Update readme sc3-plugins info

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To install the SC-HOA quark, either use the `Quarks.gui` interface or install it
 
 ```Quarks.install("https://github.com/florian-grond/SC-HOA")```
 
-In order to use this library, you will need a collection of SuperCollider UGens called _HOAUGens_. These UGens are available as part of the [sc3-plugins](https://supercollider.github.io/sc3-plugins/).See the website and GitHub repository for installation instructions. 
+In order to use this library, you will need a collection of SuperCollider UGens called _HOAUGens_. These UGens are available as part of the [sc3-plugins](https://supercollider.github.io/sc3-plugins/). See the website and GitHub repository for installation instructions. 
 
 > **note:** The HOAUGens were added to the sc3-plugins as of commit https://github.com/supercollider/sc3-plugins/commit/9326e1229a64ca82f76124a7a1a038095be22996
  

--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ To install the SC-HOA quark, either use the `Quarks.gui` interface or install it
 
 ```Quarks.install("https://github.com/florian-grond/SC-HOA")```
 
-In order to use this library, you will need to install the collection of SuperCollider plugins called _HOAUGens_.
-A PR to the SC3 plugins has been submitted, meanwhile you find compile instructions for SC3plugins + HOA here:
-https://github.com/florian-grond/sc3-pluginsHOA
-(compiled plugins SC3plugins for 3.8 and 3.9 with supernova support are also provided at this link)
+In order to use this library, you will need a collection of SuperCollider UGens called _HOAUGens_. These UGens are available as part of the [sc3-plugins](https://supercollider.github.io/sc3-plugins/).See the website and GitHub repository for installation instructions. 
 
+> **note:** The HOAUGens were added to the sc3-plugins as of commit https://github.com/supercollider/sc3-plugins/commit/9326e1229a64ca82f76124a7a1a038095be22996
+ 
 You might need additional resources to make use of SC-HOA (e.g. FIR filters for binaural decoding).
 These files can be obtained by downloading a copy of the [ambitools][1] repository. Make a copy of the folder called `FIR` and place it into your SC-HOA kernels folder.
 


### PR DESCRIPTION
This PR updates the README to point users towards the sc3-plugins repository in order to obtain the HOAUGens. Unfortunately, GitHub doesn't seem to want to format the commit hash link properly (it's supposed to appear in its short form).