### PR TITLE
Remove unused `systemSupportDir` classvar

### DIFF
--- a/HelpSource/Classes/HOA.schelp
+++ b/HelpSource/Classes/HOA.schelp
@@ -15,11 +15,6 @@ METHOD:: userSupportDir
 returns::the path to the HOA support dir. Defaults to:
 code::Platform.userAppSupportDir.dirname ++ "/HOA";::
 
-METHOD:: systemSupportDir
-
-returns::the path to the HOA support dir. Defaults to:
-code::Platform.systemAppSupportDir.dirname ++ "/HOA";::
-
 
 METHOD:: userSoundsDir
 
@@ -30,26 +25,15 @@ METHOD:: userKernelDir
 returns:: a path to the 'kernel' dir inside the ATK support dir
 
 
-METHOD:: systemSoundsDir
-
-returns:: a path to the sounds dir inside the HOA system support dir
-
-METHOD:: systemKernelDir
-
-returns:: a path to the kernel dir inside the HOA system support dir
-
 METHOD:: kernelSubdir
-name of subdirectory for kernels within code::userSupportDir:: and code::systemSupportDir::
+name of subdirectory for kernels within code::userSupportDir::
 
 METHOD:: soundsSubdir
-name of subdirectory for sounds within code::userSupportDir:: and code::systemSupportDir::
+name of subdirectory for sounds within code::userSupportDir::
 
 
 METHOD:: openUserSupportDir
 runs a unixCmd to open the userAppSupport dir. Uses 'open' (OS X only)
-
-METHOD:: openSystemSupportDir
-runs a unixCmd to open the systemAppSupport dir. Uses 'open' (OS X only)
 
 
 METHOD:: kernelDirsFor

--- a/classes/HOA.sc
+++ b/classes/HOA.sc
@@ -8,11 +8,9 @@ additions and alterations by Till Bovermann ( http://tai-studio.org )
 
 HOA {
 	classvar   <>userSupportDir; //,   <userSoundsDir,   <userKernelDir;
-	classvar <>systemSupportDir; //, <systemSoundsDir, <systemKernelDir;
 	classvar <>soundsSubdir, <>kernelSubdir;
 
 	*initClass {
-		systemSupportDir = Platform.systemAppSupportDir.dirname ++ "/HOA";
 		userSupportDir   = Platform.userAppSupportDir  .dirname ++ "/HOA";
 
 		soundsSubdir     = "sounds";
@@ -24,15 +22,9 @@ HOA {
 	*userSoundsDir {
 		^userSupportDir   +/+ soundsSubdir
 	}
-	*systemSoundsDir {
-		^systemSupportDir +/+ soundsSubdir
-	}
 
 	*userKernelDir {
 		^userSupportDir   +/+ kernelSubdir
-	}
-	*systemKernelDir {
-		^systemSupportDir +/+ kernelSubdir
 	}
 
 	*openUserSupportDir {
@@ -53,24 +45,8 @@ HOA {
 	// 	//		("mkdir \"" ++ HOA.userSupportDir ++ "\"").unixCmd;
 	// }
 
-	*openSystemSupportDir {
-		if (File.exists(systemSupportDir).not, {
-			"%: HOA System Support directory does not exist.".format(this).warn;
-			^this;
-		});
-
-		systemSupportDir.openOS;
-	}
-
 	*pr_dirsFor {|keyword, subdir, subPaths|
-		var paths;
-		// user directory takes precedence
-		paths = [userSupportDir, systemSupportDir].collect{|dir|
-			(dir +/+ subdir +/+ subPaths +/+ keyword).pathMatch;
-		}.flatten;
-
-		^paths;
-
+		^(userSupportDir +/+ subdir +/+ subPaths +/+ keyword).pathMatch
 	}
 
 	*kernelDirsFor {|keyword, subPaths|


### PR DESCRIPTION
The HOA class's `systemSupportDir` doesn't appear to be used anywhere within SC-HOA. The README only makes mention of `userSupportDir`. Since placing files in `systemSupportDir` isn't ideal, we should remove this class variable all together.