### PR TITLE
Rename variables and methods related to kernels/sounds

### DIFF
--- a/HelpSource/Classes/HOA.schelp
+++ b/HelpSource/Classes/HOA.schelp
@@ -10,30 +10,30 @@ It is modeled after the Atk class.
 
 CLASSMETHODS::
 
-METHOD:: userSupportDir
+METHOD:: resourceDir
 
-returns::the path to the HOA support dir. Defaults to:
-code::Platform.userAppSupportDir.dirname ++ "/HOA";::
-
-
-METHOD:: userSoundsDir
-
-returns:: a path to the 'sounds' dir inside the HOA support dir
-
-METHOD:: userKernelDir
-
-returns:: a path to the 'kernel' dir inside the ATK support dir
+returns:: the path to SC-HOA's resource directory. If SC-HOA was installed via Quarks, code::resourceDir:: should be equal to:
+code::Platform.userAppSupportDir +/+ "downloaded-quarks/SC-HOA/resources"::
 
 
-METHOD:: kernelSubdir
-name of subdirectory for kernels within code::userSupportDir::
+METHOD:: soundsDir
+
+returns:: the path to the 'sounds' dir inside the SC-HOA resource directory
+
+METHOD:: kernelsDir
+
+returns:: the path to the 'kernels' dir inside the SC-HOA resource directory
+
+
+METHOD:: kernelsSubdir
+name of subdirectory for kernels within the SC-HOA resource directory
 
 METHOD:: soundsSubdir
-name of subdirectory for sounds within code::userSupportDir::
+name of subdirectory for sounds within the SC-HOA resource directory
 
 
-METHOD:: openUserSupportDir
-runs a unixCmd to open the userAppSupport dir. Uses 'open' (OS X only)
+METHOD:: openResourceDir
+runs a unixCmd to open the SC-HOA resource directory.
 
 
 METHOD:: kernelDirsFor

--- a/HelpSource/Tutorials/Exercise_03_HOA_decoding_for_monitoring.schelp
+++ b/HelpSource/Tutorials/Exercise_03_HOA_decoding_for_monitoring.schelp
@@ -118,24 +118,13 @@ s.scope(26); // To see all channels we add one more to the oscilloscope
 ~decoder.source = {var in; in = \in.ar(0!~hoaNumChannels); HOADecLebedev26.ar(3, in, output_gains: 24) };
 ::
 
-Now let's load HRIR filters for each of the 26 channels:
-Download them first here link::https://github.com/sekisushai/ambitools:: and place the FIR folder in the HOA folder.
-
-Depending on the platform you have this is:
-
-~/.local/share/HOA/
-
-or
-
-~/Library/Application Support/HOA/
-
-You can find the right path by executing
+Now let's load HRIR filters for each of the 26 channels. You can find these filters inside the teletype::resource/:: directory.
 
 code::
-HOA.userSupportDir
+HOA.openResourceDir
 ::
 
-Then execute:
+To load the HRIR filters, execute the following:
 
 code::
 HOADecLebedev26.loadHrirFilters(s);
@@ -170,7 +159,6 @@ code::
 
 The previous binauralization examples are CPU costly but can in principle use personalized HRIRs, should you happen to have some measurements for the positions of Lebedev grids.
 There is another possibility to binauralize b-format For, which is a very efficient and takes advantage of the symmetry of the KU100 see the following example:
-Make sure that the binauralIRs folder and the headphoneEQ folder are under HOA/kernels/
 
 Load the IRs as well as the headphone correction filters
 code::

--- a/HelpSource/Tutorials/Exercise_05_HOA_b_format_file_playback.schelp
+++ b/HelpSource/Tutorials/Exercise_05_HOA_b_format_file_playback.schelp
@@ -46,10 +46,10 @@ s.scope(2); // let's use only two channels as we will monitor it with headphones
 
 Let's load some 16 channels 3rd order soundfiles, the filenames indicate the channel ordering as well as the normalization (ACN, N3D):
 code::
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_LePlateau_Backyard_short.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_LePlateau_Backyard_short.wav");
 ~hoaSoundFile.numChannels;
 ::
 

--- a/HelpSource/Tutorials/Exercise_06_HOA_scenes_simple_manipulations.schelp
+++ b/HelpSource/Tutorials/Exercise_06_HOA_scenes_simple_manipulations.schelp
@@ -60,7 +60,7 @@ s.scope(2); // let's use only two channels as we will monitor it with headphones
 
 We will load a very short sound file that we loop so that we can observe the soundfield transformations:
 code::
-~hoaSoundFile = Buffer.read(s,HOA.userSoundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
+~hoaSoundFile = Buffer.read(s,HOA.soundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
 ~hoaSoundFile.numChannels;
 ::
 

--- a/HelpSource/Tutorials/Exercise_07_HOA_beamforming.schelp
+++ b/HelpSource/Tutorials/Exercise_07_HOA_beamforming.schelp
@@ -70,10 +70,10 @@ s.scope(2); // let's use only two channels as we will monitor it with headphones
 
 
 code::
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_LePlateau_Backyard_short.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_LePlateau_Backyard_short.wav");
 ~hoaSoundFile.numChannels;
 ::
 

--- a/HelpSource/Tutorials/Exercise_10_HOA_decoding_for_speaker_arrays.schelp
+++ b/HelpSource/Tutorials/Exercise_10_HOA_decoding_for_speaker_arrays.schelp
@@ -45,10 +45,10 @@ s.scope(5); // let's use 5 as we play back via ITU 5.0
 
 Let's load some 16 channels 3rd order soundfiles, the filenames indicate the channel ordering as well as the normalization (ACN, N3D):
 code::
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
-~hoaSoundFile = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_LePlateau_Backyard.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
+~hoaSoundFile = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_LePlateau_Backyard.wav");
 ~hoaSoundFile.numChannels;
 ::
 

--- a/HelpSource/Tutorials/Exercise_11_HOA_NRT_using_scores_and_Buffers.schelp
+++ b/HelpSource/Tutorials/Exercise_11_HOA_NRT_using_scores_and_Buffers.schelp
@@ -49,9 +49,9 @@ We will first make a SynthDef with a very simple grain playing back a sound samp
 
 First, load a soundfile:
 code::
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
 ::
 
 

--- a/HelpSource/Tutorials/Exercise_13_HOA_NRT_conversion_script_N3D_SN3D_FUMA.schelp
+++ b/HelpSource/Tutorials/Exercise_13_HOA_NRT_conversion_script_N3D_SN3D_FUMA.schelp
@@ -42,9 +42,9 @@ code::
 ~order = 3; // al material is 3rd order
 ~hoaNumChannels = (~order+1).pow(2);
 )
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
 ::
 
 

--- a/HelpSource/Tutorials/Exercise_14_HOA_NRT_decoding_script.schelp
+++ b/HelpSource/Tutorials/Exercise_14_HOA_NRT_decoding_script.schelp
@@ -42,9 +42,9 @@ code::
 ~order = 3; // al material is 3rd order
 ~hoaNumChannels = (~order+1).pow(2);
 )
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
-~hoaSoundScene = Buffer.read(s, HOA.userSoundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro_cello.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_Montreal_Metro.wav");
+~hoaSoundScene = Buffer.read(s, HOA.soundsDir++"/eigen_ACN_N3D_CIRMMT_Foyer_short.wav");
 ::
 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Depending on your system, you will need to create the SC-HOA kernels folder in t
 
 You can find this path from within SuperCollider by executing the following:
 
-```HOA.userKernelDir```
+```HOA.kernelsDir```
 
 If you need 3rd order recordings for testing the tutorial and radial filters, feel free to [contact me](http://www.grond.at/html/submenues/submenu_contact.htm).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The SuperCollider library was written by [Florian Grond](http://www.grond.at). I
 
 Frontend classes are wrappers that select the correct low-level UGen depending on the intended ambisonics order. The b-format signal is encapsulated in a channel array, which makes the resulting SC code flexible to experiment with different orders e.g. to account for available computational resources. All arguments obey SuperCollider's Multichannel Expansion paradigm.
 
-[^1]: binary files are not included in this repository, see [Installation](#Installation) for details.
+Additional resources for SC-HOA ambisonics are found inside the [resources/](resources/) folder. The included [FIR filters](resources/kernels/FIR/) are taken from [ambitools][1]. The [binraural IRs](resources/kernels/binauralIRs/) and [heaphone EQs](resources/kernels/headphoneEQ/) are taken from the [IEM Plugin Suite](https://git.iem.at/audioplugins/IEMPluginSuite)'s BinauralDecoder.
 
 ## Installation
 
@@ -24,19 +24,6 @@ In order to use this library, you will need a collection of SuperCollider UGens 
 
 > **note:** The HOAUGens were added to the sc3-plugins as of commit https://github.com/supercollider/sc3-plugins/commit/9326e1229a64ca82f76124a7a1a038095be22996
  
-You might need additional resources to make use of SC-HOA (e.g. FIR filters for binaural decoding).
-These files can be obtained by downloading a copy of the [ambitools][1] repository. Make a copy of the folder called `FIR` and place it into your SC-HOA kernels folder.
-
-Depending on your system, you will need to create the SC-HOA kernels folder in the following locations:
-
-* Linux `~/.local/share/HOA/kernels/`
-* macOS `~/Library/Application Support/HOA/kernels/`
-* Windows `C:\Users\_your-username_\AppData\Local\HOA\kernels\`
-
-You can find this path from within SuperCollider by executing the following:
-
-```HOA.kernelsDir```
-
 If you need 3rd order recordings for testing the tutorial and radial filters, feel free to [contact me](http://www.grond.at/html/submenues/submenu_contact.htm).
 
 ## Acknowledgements

--- a/classes/HOA.sc
+++ b/classes/HOA.sc
@@ -7,34 +7,27 @@ additions and alterations by Till Bovermann ( http://tai-studio.org )
 
 
 HOA {
-	classvar   <>userSupportDir; //,   <userSoundsDir,   <userKernelDir;
-	classvar <>soundsSubdir, <>kernelSubdir;
+	classvar <>resourceDir;
+	classvar <>soundsSubdir, <>kernelsSubdir;
 
 	*initClass {
-		userSupportDir   = Platform.userAppSupportDir  .dirname ++ "/HOA";
+		// find the path to this file, then move up one level and append "resources/"
+		resourceDir = this.class.filenameSymbol.asString.dirname.dirname +/+ "resources";
 
-		soundsSubdir     = "sounds";
-		kernelSubdir     = "kernels";
-
+		soundsSubdir = "sounds";
+		kernelsSubdir = "kernels";
 	}
 
-
-	*userSoundsDir {
-		^userSupportDir   +/+ soundsSubdir
+	*soundsDir {
+		^resourceDir +/+ soundsSubdir
 	}
 
-	*userKernelDir {
-		^userSupportDir   +/+ kernelSubdir
+	*kernelsDir {
+		^resourceDir +/+ kernelsSubdir
 	}
 
-	*openUserSupportDir {
-		if (File.exists(Atk.userSupportDir).not, {
-			HOA.userSupportDir.openOS;
-		}, {
-			"\n%: User Support directory does not exist. Run\n"
-			"\tthis.createUserSupportDir\nto create it".format(this, this).warn;
-			^this;
-		})
+	*openResourceDir {
+		resourceDir.openOS
 	}
 
 	// not really a good idea, we cannot populate it from within SC anyhow...
@@ -46,11 +39,11 @@ HOA {
 	// }
 
 	*pr_dirsFor {|keyword, subdir, subPaths|
-		^(userSupportDir +/+ subdir +/+ subPaths +/+ keyword).pathMatch
+		^(resourceDir +/+ subdir +/+ subPaths +/+ keyword).pathMatch
 	}
 
 	*kernelDirsFor {|keyword, subPaths|
-		^this.pr_dirsFor(keyword, kernelSubdir, subPaths);
+		^this.pr_dirsFor(keyword, kernelsSubdir, subPaths);
 	}
 	*soundsDirsFor {|keyword, subPaths|
 		^this.pr_dirsFor(keyword, soundsSubdir, subPaths);

--- a/classes/HOAAmbiDecoderHelper.sc
+++ b/classes/HOAAmbiDecoderHelper.sc
@@ -5,8 +5,8 @@
 
 HOAAmbiDecoderHelper {
 
-	var   <>ambiToolboxPath; //,   <userSoundsDir,   <userKernelDir;
-	var   <>speakerArrayName; //,  <userSoundsDir,   <userKernelDir;
+	var   <>ambiToolboxPath; //,   <soundsDir,   <kernelsDir;
+	var   <>speakerArrayName; //,  <soundsDir,   <kernelsDir;
 	var   <>speakerPositions; //,
 	var   <>sweeterPositions; //,
 	var   <>speakerLabels; //
@@ -351,4 +351,4 @@ p.close;					// close the pipe to avoid that nasty buildup \n
 			       path_ADT++"examples/"++this.speakerArrayName++".schelp "++
 			       path_ADT++this.speakerArrayName++"/"++this.speakerArrayName++".schelp""');\n");
         */
-	
+


### PR DESCRIPTION
This PR renames class variables and methods related to the kernels and sounds directories. The changes include:

- renamed `HOA.userSupportDir` -> `HOA.resourceDir`
    - `HOA.resourceDir` points to folder `resources/`
- renamed `HOA.userSoundsDir` -> `HOA.soundsDir`
    - `HOA.soundsDir` points to folder `resources/sounds/`
- renamed `HOA.userKernelDir` -> `HOA.kernelsDir`
    - `HOA.kernelsDir` points to folder `resources/kernels/`
- renamed `HOA.openUserSupportDir` -> `HOA.openResourceDir`
    - `HOA.openResourceDir` opens `HOA.resourceDir`
- renamed `HOA.kernelSubdir -> `HOA.kernelsSubdir` (pluralized kernels)
- Updated the Helpfiles and Tutorials
- Updated the README
