### PR TITLE
use select method on file list

### DIFF
--- a/classes/HOABinaural.sc
+++ b/classes/HOABinaural.sc
@@ -66,8 +66,7 @@ HOABinaural{
 		if(headPhoneIRs.notNil) { ^headPhoneIRs };
 
 		pathname = PathName(HOA.kernelsDir +/+ "headphoneEQ");
-		// keep only files with .wav extension. counterintuitive, but correct.
-		files = pathname.files.takeThese { |file| file.extension != "wav" };
+		files = pathname.files.select { |file| file.extension == "wav" };
 		headPhones = Array.newClear(files.size);
 		headPhoneIRs = files.collect { |file, index|
 			headPhones.put(index, file.fileNameWithoutExtension);


### PR DESCRIPTION
This PR is a quick fix for `HOABinaural.loadHeadphoneCorrections`. Using the method `.select` is a better choice than `.takeThese`.