### PR TITLE
reinstate manual focus in beamformations

### DIFF
--- a/classes/HOABeamDirac2Hoa.sc
+++ b/classes/HOABeamDirac2Hoa.sc
@@ -1,6 +1,6 @@
 HOABeamDirac2Hoa{
 
-	*ar { |order, in, az, ele, level, on = 1, crossfade|
+	*ar { |order, in, az, ele, level, on = 1, timer_manual = 0, crossfade = 1, focus = 0|
 		// az = az * -1; ele = ele * -1;  // the Faust Ugens seem to have those reversed
 		case{order == 1}
                 		{ var in1, // declare variables for the b-format array
@@ -9,7 +9,7 @@ HOABeamDirac2Hoa{
 			                     in2, in3, in4 = in;
 			              ^HOABeamDirac2HOA1.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
-				                                            azimuth: az, elevation: ele, gain:level, on: on, crossfade:crossfade)} // and with the args from the *ar method
+				                                            azimuth: az, elevation: ele, gain: level, on: on, timer_manual: timer_manual, crossfade: crossfade, focus: focus)} // and with the args from the *ar method
 		       {order == 2}
                 		{var in1, // declare variables for the b-format array
 			                   in2, in3, in4,
@@ -20,7 +20,7 @@ HOABeamDirac2Hoa{
 			              ^HOABeamDirac2HOA2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
-				                                            azimuth: az, elevation: ele, gain:level, on: on, crossfade:crossfade)} // and with the args from the *ar method
+				                                            azimuth: az, elevation: ele, gain: level, on: on, timer_manual: timer_manual, crossfade: crossfade, focus: focus)} // and with the args from the *ar method
                {order == 3}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -34,7 +34,7 @@ HOABeamDirac2Hoa{
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           azimuth: az, elevation: ele, gain:level, on: on, crossfade:crossfade)} // and with the args from the *ar method
+				                                           azimuth: az, elevation: ele, gain: level, on: on, timer_manual: timer_manual, crossfade: crossfade, focus: focus)} // and with the args from the *ar method
                {order == 4}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -51,7 +51,7 @@ HOABeamDirac2Hoa{
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
 				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25,
-				                                           azimuth: az, elevation: ele, gain:level, on: on, crossfade:crossfade)} // and with the args from the *ar method
+				                                           azimuth: az, elevation: ele, gain: level, on: on, timer_manual: timer_manual, crossfade: crossfade, focus: focus)} // and with the args from the *ar method
                {order == 5}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -71,7 +71,7 @@ HOABeamDirac2Hoa{
 				                                           in10, in11, in12, in13, in14, in15, in16,
 				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25,
 				                                           in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36,
-				                                           azimuth: az, elevation: ele, gain:level, on: on, crossfade:crossfade)} // and with the args from the *ar method
+				                                           azimuth: az, elevation:  ele, gain:level, on: on, timer_manual: timer_manual, crossfade: crossfade, focus: focus)} // and with the args from the *ar method
 				{"this order is not implemented".postln}
 	}
 

--- a/classes/HOABeamHCard2Hoa.sc
+++ b/classes/HOABeamHCard2Hoa.sc
@@ -1,6 +1,6 @@
 HOABeamHCard2Hoa{
 
-	*ar { |order, in, az, ele, cardOrder = 1|
+	*ar { |order, in, az, ele, int_float = 0, cardOrder = 1|
 		// 		az = az.neg; ele = ele.neg; // the Faust Ugens seem to have those reversed
 		case{order == 1}
                 		{ var in1, // declare variables for the b-format array
@@ -9,7 +9,7 @@ HOABeamHCard2Hoa{
 			                     in2, in3, in4 = in;
 			              ^HOABeamHCardio2HOA1.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
-				                                            azimuth: az, elevation: ele, order:cardOrder)} // and with the args from the *ar method
+				                                            azimuth: az, elevation: ele, int_float: int_float, order:cardOrder)} // and with the args from the *ar method
 		       {order == 2}
                 		{var in1, // declare variables for the b-format array
 			                   in2, in3, in4,
@@ -20,7 +20,7 @@ HOABeamHCard2Hoa{
 			              ^HOABeamHCardio2HOA2.ar(in1, // return the Ugen with the b-format channels
 				                                            in2, in3, in4,
 				                                            in5, in6, in7, in8, in9,
-				                                            azimuth: az, elevation: ele, order:cardOrder)}// and with the args from the *ar method
+				                                            azimuth: az, elevation: ele, int_float: int_float, order:cardOrder)}// and with the args from the *ar method
                {order == 3}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,
@@ -34,7 +34,7 @@ HOABeamHCard2Hoa{
 				                                           in2, in3, in4,
 				                                           in5, in6, in7, in8, in9,
 				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                            azimuth: az, elevation: ele, order:cardOrder)} // and with the args from the *ar method
+				                                            azimuth: az, elevation: ele, int_float: int_float, order:cardOrder)} // and with the args from the *ar method
                {order == 4}
                 		{var in1, // declare variables for the b-format array
 			                   in2,   in3,   in4,


### PR DESCRIPTION
as mentioned in #28, the functionality was retired in 
1a30ed9

If this is a problem, I could add separately 2 "manual" classes.
Let me know
