### PR TITLE
simplify ugen selection

### DIFF
--- a/classes/HOABeamHCard2Hoa.sc
+++ b/classes/HOABeamHCard2Hoa.sc
@@ -1,89 +1,29 @@
 HOABeamHCard2Hoa{
 
 	*ar { |order, in, az, ele, int_float = 0, cardOrder = 1|
-		// 		az = az.neg; ele = ele.neg; // the Faust Ugens seem to have those reversed
-		case{order == 1}
-                		{ var in1, // declare variables for the b-format array
-			                    in2, in3, in4;
-                               #in1, // distribute the channels from the array
-			                     in2, in3, in4 = in;
-			              ^HOABeamHCardio2HOA1.ar(in1, // return the Ugen with the b-format channels
-				                                            in2, in3, in4,
-				                                            azimuth: az, elevation: ele, int_float: int_float, order:cardOrder)} // and with the args from the *ar method
-		       {order == 2}
-                		{var in1, // declare variables for the b-format array
-			                   in2, in3, in4,
-			                   in5, in6, in7, in8, in9;
-                             #in1, // distribute the channels from the array
-			                   in2, in3, in4,
-			                   in5, in6, in7, in8, in9 = in;
-			              ^HOABeamHCardio2HOA2.ar(in1, // return the Ugen with the b-format channels
-				                                            in2, in3, in4,
-				                                            in5, in6, in7, in8, in9,
-				                                            azimuth: az, elevation: ele, int_float: int_float, order:cardOrder)}// and with the args from the *ar method
-               {order == 3}
-                		{var in1, // declare variables for the b-format array
-			                   in2,   in3,   in4,
-			                   in5,   in6,   in7,   in8,   in9,
-			                   in10, in11, in12, in13, in14, in15, in16;
-                              #in1, // distribute the channels from the array
-			                    in2, in3, in4,
-			                    in5, in6, in7, in8, in9,
-			                    in10, in11, in12, in13, in14, in15, in16 = in;
-			             ^HOABeamHCardio2HOA3.ar(in1,  // return the Ugen with the b-format channels
-				                                           in2, in3, in4,
-				                                           in5, in6, in7, in8, in9,
-				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                            azimuth: az, elevation: ele, int_float: int_float, order:cardOrder)} // and with the args from the *ar method
-               {order == 4}
-                		{var in1, // declare variables for the b-format array
-			                   in2,   in3,   in4,
-			                   in5,   in6,   in7,   in8,   in9,
-			                   in10, in11, in12, in13, in14, in15, in16,
-			                   in17, in18, in19, in20, in21, in22, in23, in24, in25;
-                              #in1, // distribute the channels from the array
-			                    in2, in3, in4,
-			                    in5, in6, in7, in8, in9,
-			                    in10, in11, in12, in13, in14, in15, in16,
-			                    in17, in18, in19, in20, in21, in22, in23, in24, in25 = in;
-				"order 4 is not implemented for HOABeamHCardio2HOA. \n returning unaltered bformat.".postln;
-			^[ in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25 ]
-		/*
-			^HOABeamHCardio2HOA4.ar(in1,  // return the Ugen with the b-format channels
-				                                           in2, in3, in4,
-				                                           in5, in6, in7, in8, in9,
-				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25,
-				                                            azimuth: az, elevation: ele, order:cardOrder)
-		*/
-			} // and with the args from the *ar method
-               {order == 5}
-                		{var in1, // declare variables for the b-format array
-			                   in2,   in3,   in4,
-			                   in5,   in6,   in7,   in8,   in9,
-			                   in10, in11, in12, in13, in14, in15, in16,
-			                   in17, in18, in19, in20, in21, in22, in23, in24, in25,
-			                   in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36;
-                              #in1, // distribute the channels from the array
-			                    in2, in3, in4,
-			                    in5, in6, in7, in8, in9,
-			                    in10, in11, in12, in13, in14, in15, in16,
-			                    in17, in18, in19, in20, in21, in22, in23, in24, in25,
-			                    in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36 = in;
-				"order 5 is not implemented for HOABeamHCardio2HOA. \n returning unaltered bformat.".postln;
-			^[ in1, in2, in3, in4, in5, in6, in7, in8, in9, in10, in11, in12, in13, in14, in15, in16, in17, in18, in19, in20, in21, in22, in23, in24, in25, in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36]
+		var numInputs, argList, ugen;
 
-			/*
-			^HOABeamHCardio2HOA5.ar(in1,  // return the Ugen with the b-format channels
-				                                           in2, in3, in4,
-				                                           in5, in6, in7, in8, in9,
-				                                           in10, in11, in12, in13, in14, in15, in16,
-				                                           in17, in18, in19, in20, in21, in22, in23, in24, in25,
-				                                           in26, in27, in28, in29, in30, in31, in32, in33, in34, in35, in36,
-				                                            azimuth: az, elevation: ele, order:cardOrder) // and with the args from the *ar method
-				{"this order is not implemented".postln
-			*/
-		}
+		numInputs = switch(order)
+		{ 1 } { 4 }
+		{ 2 } { 9 }
+		{ 3 } { 16 }
+		{ 4 } { 25 }
+		{ 5 } { 36 };
+		{ 36 } // default
+
+		if(order > 3) {
+			"order % is not implemented for HOABeamHCardio2HOA. \n returning unaltered bformat.".format(order).postln;
+			^in.keep(numInputs)
+		}:
+
+		ugen = switch(order)
+		{ 1 } { HOABeamHCardio2HOA1 }
+		{ 2 } { HOABeamHCardio2HOA2 }
+		{ 3 } { HOABeamHCardio2HOA3 };
+
+		argList = in.keep(numInputs) ++ [az, ele, int_float, cardOrder];
+
+		^ugen.ar(*argList)
 	}
 
 }


### PR DESCRIPTION
Here is a suggestion of how to simplify the code for UGen selection. Let me know if that makes sense to you, I could help with other cases as well if you like it. I think it makes the library clearer to read. As a side-effect, we get rid of non-inlined functions (#51).

Of course the critical thing is testing the correctness of the changes, which would be something I can't properly do myself.
